### PR TITLE
Updated all dependencies to versions with unified mode

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -71,14 +71,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           exclude_labels: "duplicate,question,invalid,wontfix,skip-changelog"
-
+          release_branch: "master"
       - name: commit updated changelog
         uses: EndBug/add-and-commit@v7
         with:
           message: "[CHANGELOG] Updated changelog"
           add: "CHANGELOG.md"
           signoff: true
-          branch: master
+          branch: "master"
 
       - name: Create pull request
         uses: repo-sync/pull-request@v2
@@ -99,6 +99,7 @@ jobs:
         uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           tag_name: ${{ github.event.release.tag_name }}
+          delete_release: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,8 +12,9 @@ source_url 'https://github.com/codenamephp/chef.cookbook.chef'
 
 supports 'debian'
 
-depends 'codenamephp_chef', '~> 2.1'
-depends 'codenamephp_dev', '~> 3.0'
+depends 'codenamephp_chef', '~> 3.0'
+depends 'codenamephp_dev', '~> 4.0'
 depends 'codenamephp_docker', '~> 3.0'
 depends 'codenamephp_edge', '~> 1.0'
-depends 'codenamephp_gui', '~> 2.1'
+depends 'codenamephp_gnome', '~> 1.0'
+depends 'codenamephp_vscode', '~> 1.0'

--- a/recipes/chef.rb
+++ b/recipes/chef.rb
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+codenamephp_chef_repository 'Add chef repository'
 codenamephp_chef_workstation 'Install chef workstation'
 codenamephp_chef_environment 'Install chef environment for users' do
   users node['users']

--- a/recipes/gnome.rb
+++ b/recipes/gnome.rb
@@ -18,17 +18,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-codenamephp_gui_gnome 'install gnome gui'
+codenamephp_gnome_package 'install gnome gui'
 
-codenamephp_gui_gnome_gsettings 'Set display idle delay' do
-  schema CodenamePHP::Gui::Helper::Gnome::GSettings::SCHEMA_DESKTOP_SESSION
-  key CodenamePHP::Gui::Helper::Gnome::GSettings::KEY_DESKTOP_SESSION_IDLE_DELAY
+codenamephp_gnome_gsettings 'Set display idle delay' do
+  schema CodenamePHP::Gnome::GSettings::SCHEMA_DESKTOP_SESSION
+  key CodenamePHP::Gnome::GSettings::KEY_DESKTOP_SESSION_IDLE_DELAY
   value '0'
   users node['users']
 end
 
-codenamephp_gui_gnome_keyboard_shortcut 'Terminal' do
+codenamephp_gnome_keyboard_shortcut 'Terminal' do
   command 'gnome-terminal --maximize'
-  binding "#{CodenamePHP::Gui::Helper::Gnome::GSettings::Keys::SUPER}#{CodenamePHP::Gui::Helper::Gnome::GSettings::Keys::ALT}t"
+  binding "#{CodenamePHP::Gnome::GSettings::Keys::SUPER}#{CodenamePHP::Gnome::GSettings::Keys::ALT}t"
   users node['users']
 end

--- a/recipes/vscode.rb
+++ b/recipes/vscode.rb
@@ -18,7 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-codenamephp_dev_vscode 'Install VSCode'
-codenamephp_dev_vscode_extensions 'Install VSCode extensions' do
+codenamephp_vscode_repository 'Install apt repo'
+codenamephp_vscode_package 'Install VSCode'
+codenamephp_vscode_extensions 'Install VSCode extensions' do
   users_extensions Hash[node['users'].collect { |username| [username, node['codenamephp']['workstation_chef']['vscode']['extensions']] }]
 end

--- a/spec/unit/recipes/gnome_spec.rb
+++ b/spec/unit/recipes/gnome_spec.rb
@@ -27,15 +27,15 @@ describe 'codenamephp_workstation_chef::gnome' do
     end
 
     it 'installs gnome' do
-      expect(chef_run).to install_codenamephp_gui_gnome('install gnome gui')
+      expect(chef_run).to install_codenamephp_gnome_package('install gnome gui')
     end
 
     it 'sets the settings' do
-      expect(chef_run).to set_codenamephp_gui_gnome_gsettings('Set display idle delay')
+      expect(chef_run).to set_codenamephp_gnome_gsettings('Set display idle delay')
     end
 
     it 'sets the keyboard shortcuts' do
-      expect(chef_run).to set_codenamephp_gui_gnome_keyboard_shortcut('Terminal')
+      expect(chef_run).to set_codenamephp_gnome_keyboard_shortcut('Terminal')
     end
   end
 end

--- a/spec/unit/recipes/vscode_spec.rb
+++ b/spec/unit/recipes/vscode_spec.rb
@@ -26,12 +26,16 @@ describe 'codenamephp_workstation_chef::vscode' do
       expect { chef_run }.to_not raise_error
     end
 
+    it 'Adds apt repository' do
+      expect(chef_run).to install_codenamephp_vscode_repository('Install apt repo')
+    end
+
     it 'Installs VSCode' do
-      expect(chef_run).to install_codenamephp_dev_vscode('Install VSCode')
+      expect(chef_run).to install_codenamephp_vscode_package('Install VSCode')
     end
 
     it 'Installs default extensions for user chef' do
-      expect(chef_run).to install_codenamephp_dev_vscode_extensions('Install VSCode extensions').with(
+      expect(chef_run).to install_codenamephp_vscode_extensions('Install VSCode extensions').with(
         users_extensions: {
           'chef' => ['chef-software.chef', 'eamodio.gitlens', 'github.vscode-pull-request-github'],
         }
@@ -44,7 +48,7 @@ describe 'codenamephp_workstation_chef::vscode' do
     override_attributes['codenamephp']['workstation_chef']['vscode']['extensions'] = %w(ext1 ext2)
 
     it 'Installs custom extensions for user user1 and user2' do
-      expect(chef_run).to install_codenamephp_dev_vscode_extensions('Install VSCode extensions').with(
+      expect(chef_run).to install_codenamephp_vscode_extensions('Install VSCode extensions').with(
         users_extensions: {
           'user1' => %w(ext1 ext2),
           'user2' => %w(ext1 ext2),


### PR DESCRIPTION
Since unified_mode is comming and not having it is deprecated and the tests are set up to fail on deprecations the dependencies have to be updated. This includes newer version but I used this opportunity to deprecate some older cookbooks and transfer some recipes/resources to dedicated cookbooks that are smaller and more focused.