### PR TITLE
Added recipes for locale and timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ default recipe in your runlist.
 ## Attributes
 - `default['users']`: The usernames that should be created and that receive the bash management and chef configs, defaults to `['chef']`
 - `default['codenamephp']['workstation_chef']['vscode']['extensions']`: An array of extension names that will be installed for the users for vscode, defaults to `['chef-software.chef', 'eamodio.gitlens', 'github.vscode-pull-request-github']`
+- `default['codenamephp']['workstation_chef']['timezone']`: The timezone to set, defaults to 'Europe/Berlin'
+- `default['codenamephp']['workstation_chef']['locale']`: The locale to set, defaults to 'de_DE.UTF-8'
 
 ## Recipes
 ### Default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,3 +2,5 @@
 
 default['users'] = ['chef']
 default['codenamephp']['workstation_chef']['vscode']['extensions'] = ['chef-software.chef', 'eamodio.gitlens', 'github.vscode-pull-request-github']
+default['codenamephp']['workstation_chef']['timezone'] = 'Europe/Berlin'
+default['codenamephp']['workstation_chef']['locale'] = 'de_DE.UTF-8'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,8 @@ package 'postfix' do
   action :purge
 end
 
+include_recipe '::locale'
+include_recipe '::timezone'
 include_recipe '::keyboard_layout'
 include_recipe '::docker'
 include_recipe '::chef'

--- a/recipes/locale.rb
+++ b/recipes/locale.rb
@@ -1,0 +1,3 @@
+locale 'Set system locale' do
+  lang node['codenamephp']['workstation_chef']['locale']
+end

--- a/recipes/timezone.rb
+++ b/recipes/timezone.rb
@@ -1,0 +1,3 @@
+timezone 'Set timezone' do
+  timezone node['codenamephp']['workstation_chef']['timezone']
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -45,5 +45,13 @@ describe 'codenamephp_workstation_chef::default' do
     it 'includes keyboard_layout recipe' do
       expect(chef_run).to include_recipe('codenamephp_workstation_chef::keyboard_layout')
     end
+
+    it 'includes locale recipe' do
+      expect(chef_run).to include_recipe('codenamephp_workstation_chef::locale')
+    end
+
+    it 'includes timezone recipe' do
+      expect(chef_run).to include_recipe('codenamephp_workstation_chef::timezone')
+    end
   end
 end

--- a/spec/unit/recipes/locale_spec.rb
+++ b/spec/unit/recipes/locale_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: codenamephp_workstation_chef
+# Spec:: locale
+#
+# Copyright:: 2020, CodenamePHP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'codenamephp_workstation_chef::locale' do
+  context 'When all attributes are default' do
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'sets the locale' do
+      expect(chef_run).to update_locale('Set system locale').with(lang: 'de_DE.UTF-8')
+    end
+  end
+
+  context 'With custom locale' do
+    override_attributes['codenamephp']['workstation_chef']['locale'] = 'some locale'
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'sets the locale' do
+      expect(chef_run).to update_locale('Set system locale').with(lang: 'some locale')
+    end
+  end
+end

--- a/spec/unit/recipes/timezone_spec.rb
+++ b/spec/unit/recipes/timezone_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: codenamephp_workstation_chef
+# Spec:: timezone
+#
+# Copyright:: 2020, CodenamePHP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'codenamephp_workstation_chef::timezone' do
+  context 'When all attributes are default' do
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'sets the timezone' do
+      expect(chef_run).to set_timezone('Set timezone').with(timezone: 'Europe/Berlin')
+    end
+  end
+
+  context 'With custom timezone' do
+    override_attributes['codenamephp']['workstation_chef']['timezone'] = 'some timezone'
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'sets the locale' do
+      expect(chef_run).to set_timezone('Set timezone').with(timezone: 'some timezone')
+    end
+  end
+end

--- a/test/integration/default/locale_test.rb
+++ b/test/integration/default/locale_test.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+describe command('cat /etc/locale.conf') do
+  its('stdout') { should match(/LANG=de_DE.UTF-8/) }
+end

--- a/test/integration/default/timezone_test.rb
+++ b/test/integration/default/timezone_test.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+describe command('timedatectl') do
+  its('stdout') { should match %r{Time zone: Europe/Berlin} }
+end


### PR DESCRIPTION
The timezone and locale are now set by default. They can be change by setting attributes:

- default['codenamephp']['workstation_chef']['timezone'] = 'Europe/Berlin'
- default['codenamephp']['workstation_chef']['locale'] = 'de_DE.UTF-8'